### PR TITLE
support bosh networks defaults for multi-network jobs

### DIFF
--- a/bosh/bosh_manifest.go
+++ b/bosh/bosh_manifest.go
@@ -52,6 +52,7 @@ type ConsumesLink struct {
 type Network struct {
 	Name      string   `yaml:"name"`
 	StaticIPs []string `yaml:"static_ips,omitempty"`
+	Default   []string `yaml:"default,omitempty"`
 }
 
 type Update struct {

--- a/bosh/bosh_manifest_test.go
+++ b/bosh/bosh_manifest_test.go
@@ -60,6 +60,7 @@ var _ = Describe("de(serialising) BOSH manifests", func() {
 					{
 						Name:      "a-network",
 						StaticIPs: []string{"10.0.0.0"},
+						Default:   []string{"dns"},
 					},
 				},
 			},

--- a/bosh/fixtures/manifest.yml
+++ b/bosh/fixtures/manifest.yml
@@ -30,6 +30,7 @@ instance_groups:
     networks:
       - name: a-network
         static_ips: [10.0.0.0]
+        default: [dns]
 
   - name: an-errand
     lifecycle: errand


### PR DESCRIPTION
looking at this again, we should actually add a test to ensure that the `omitempty` is being obeyed: let's have another network without `Default`
