### PR TITLE
Add variables section support to BOSH manifest

### DIFF
--- a/bosh/bosh_manifest.go
+++ b/bosh/bosh_manifest.go
@@ -22,6 +22,13 @@ type BoshManifest struct {
 	InstanceGroups []InstanceGroup        `yaml:"instance_groups"`
 	Update         Update                 `yaml:"update"`
 	Properties     map[string]interface{} `yaml:"properties,omitempty"`
+	Variables      []Variable             `yaml:"variables,omitempty"`
+}
+
+type Variable struct {
+	Name    string                 `yaml:"name"`
+	Type    string                 `yaml:"type"`
+	Options map[string]interface{} `yaml:"options,omitempty"`
 }
 
 type Release struct {

--- a/bosh/bosh_manifest_test.go
+++ b/bosh/bosh_manifest_test.go
@@ -109,6 +109,21 @@ var _ = Describe("de(serialising) BOSH manifests", func() {
 			MaxInFlight:     4,
 			Serial:          boolPointer(false),
 		},
+		Variables: []bosh.Variable{
+			bosh.Variable{
+				Name: "admin_password",
+				Type: "password",
+			},
+			bosh.Variable{
+				Name: "default_ca",
+				Type: "certificate",
+				Options: map[string]interface{}{
+					"is_ca":             true,
+					"common_name":       "some-ca",
+					"alternative_names": []string{"some-other-ca"},
+				},
+			},
+		},
 	}
 
 	It("serialises bosh manifests", func() {
@@ -143,6 +158,7 @@ var _ = Describe("de(serialising) BOSH manifests", func() {
 				UpdateWatchTime: "30000-180000",
 				MaxInFlight:     4,
 			},
+			Variables: []bosh.Variable{},
 		}
 
 		content, err := yaml.Marshal(emptyManifest)
@@ -158,5 +174,22 @@ var _ = Describe("de(serialising) BOSH manifests", func() {
 		Expect(content).NotTo(ContainSubstring("consumes:"))
 		Expect(content).NotTo(ContainSubstring("properties:"))
 		Expect(content).NotTo(ContainSubstring("serial:"))
+		Expect(content).NotTo(ContainSubstring("variables:"))
 	})
+
+	It("omits optional options from Variables", func() {
+		emptyManifest := bosh.BoshManifest{
+			Variables: []bosh.Variable{
+				bosh.Variable{
+					Name: "admin_password",
+					Type: "password",
+				},
+			},
+		}
+
+		content, err := yaml.Marshal(emptyManifest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(content).NotTo(ContainSubstring("options:"))
+	})
+
 })

--- a/bosh/fixtures/manifest.yml
+++ b/bosh/fixtures/manifest.yml
@@ -44,6 +44,15 @@ instance_groups:
 properties:
   foo: bar
 
+variables:
+- name: admin_password
+  type: password
+- name: default_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: some-ca
+    alternative_names: [some-other-ca]
 update:
   canaries: 1
   canary_watch_time: 30000-180000


### PR DESCRIPTION
Allow the service adapter to generate BOSH manifest with the [variables](https://bosh.io/docs/manifest-v2.html#variables) section.

KUBO requires this functionality for integration with CredHub.