### PR TITLE
Add migrated_from to bosh manifest instance group

### DIFF
--- a/bosh/bosh_manifest.go
+++ b/bosh/bosh_manifest.go
@@ -54,6 +54,11 @@ type InstanceGroup struct {
 	AZs                []string               `yaml:"azs,omitempty"`
 	Networks           []Network              `yaml:"networks"`
 	Properties         map[string]interface{} `yaml:"properties,omitempty"`
+	MigratedFrom       []Migration            `yaml:"migrated_from,omitempty"`
+}
+
+type Migration struct {
+	Name string `yaml:"name"`
 }
 
 type Network struct {

--- a/bosh/bosh_manifest_test.go
+++ b/bosh/bosh_manifest_test.go
@@ -79,6 +79,11 @@ var _ = Describe("de(serialising) BOSH manifests", func() {
 						Default:   []string{"dns"},
 					},
 				},
+				MigratedFrom: []bosh.Migration{
+					{
+						Name: "old-instance-group-name",
+					},
+				},
 			},
 			{
 				Name:      "an-errand",
@@ -175,6 +180,7 @@ var _ = Describe("de(serialising) BOSH manifests", func() {
 		Expect(content).NotTo(ContainSubstring("properties:"))
 		Expect(content).NotTo(ContainSubstring("serial:"))
 		Expect(content).NotTo(ContainSubstring("variables:"))
+		Expect(content).NotTo(ContainSubstring("migrated_from:"))
 	})
 
 	It("omits optional options from Variables", func() {

--- a/bosh/fixtures/manifest.yml
+++ b/bosh/fixtures/manifest.yml
@@ -32,6 +32,8 @@ instance_groups:
       - name: a-network
         static_ips: [10.0.0.0]
         default: [dns]
+    migrated_from:
+    - name: old-instance-group-name
 
   - name: an-errand
     lifecycle: errand

--- a/serviceadapter/domain.go
+++ b/serviceadapter/domain.go
@@ -165,6 +165,7 @@ type InstanceGroup struct {
 	Networks           []string     `json:"networks" validate:"required"`
 	AZs                []string     `json:"azs" validate:"required,min=1"`
 	Lifecycle          string       `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty"`
+	MigratedFrom       []Migration  `yaml:"migrated_from,omitempty" json:"migrated_from,omitempty"`
 }
 
 func (i *InstanceGroup) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -182,6 +183,10 @@ func (i *InstanceGroup) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*i = InstanceGroup(tmp)
 
 	return nil
+}
+
+type Migration struct {
+	Name string `yaml:"name" json:"name"`
 }
 
 type Update struct {

--- a/serviceadapter/domain_test.go
+++ b/serviceadapter/domain_test.go
@@ -127,7 +127,10 @@ var _ = Describe("Domain", func() {
 							"example-az"
 						],
 						"instances": 1,
-						"lifecycle": "errand"
+						"lifecycle": "errand",
+						"migrated_from": [
+							{"name": "old-server"}
+						]
 					}
 				],
 				"properties": {
@@ -152,6 +155,9 @@ var _ = Describe("Domain", func() {
 					AZs:                []string{"example-az"},
 					Instances:          1,
 					Lifecycle:          "errand",
+					MigratedFrom: []serviceadapter.Migration{
+						{Name: "old-server"},
+					},
 				}},
 				Properties: serviceadapter.Properties{"example": "property"},
 				Update: &serviceadapter.Update{

--- a/serviceadapter/instance_group_mapping.go
+++ b/serviceadapter/instance_group_mapping.go
@@ -49,6 +49,15 @@ func GenerateInstanceGroupsWithNoProperties(
 		if err != nil {
 			return nil, err
 		}
+
+		var migrations []bosh.Migration
+
+		if len(instanceGroup.MigratedFrom) > 0 {
+			for _, migration := range instanceGroup.MigratedFrom {
+				migrations = append(migrations, bosh.Migration{Name: migration.Name})
+			}
+		}
+
 		boshInstanceGroup := bosh.InstanceGroup{
 			Name:               instanceGroup.Name,
 			Instances:          instanceGroup.Instances,
@@ -60,6 +69,7 @@ func GenerateInstanceGroupsWithNoProperties(
 			Networks:           networks,
 			Jobs:               boshJobs,
 			Lifecycle:          instanceGroup.Lifecycle,
+			MigratedFrom:       migrations,
 		}
 		boshInstanceGroups = append(boshInstanceGroups, boshInstanceGroup)
 	}

--- a/serviceadapter/instance_group_mapping_test.go
+++ b/serviceadapter/instance_group_mapping_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Instance Groups Mapping", func() {
 				Instances:          7,
 				Networks:           []string{"an-etwork", "another-etwork"},
 				AZs:                []string{"an-az", "jay-z"},
+				MigratedFrom:       []Migration{{Name: "old-instance-group"}},
 			},
 			{
 				Name:               "another-instance-group",
@@ -84,6 +85,9 @@ var _ = Describe("Instance Groups Mapping", func() {
 				Jobs: []bosh.Job{
 					{Name: "important-job", Release: "real-release"},
 					{Name: "extra-job", Release: "good-release"},
+				},
+				MigratedFrom: []bosh.Migration{
+					{Name: "old-instance-group"},
 				},
 			},
 				bosh.InstanceGroup{


### PR DESCRIPTION
This allows service authors to generate manifests which take advantage of [bosh's `migrated_from` feature](https://bosh.io/docs/migrated-from.html), allowing them to change the name of a deployed instance group.

[#148133793]

Signed-off-by: Simon Jones <sijones@pivotal.io>