### PR TITLE
Added support for tags in the manifest

### DIFF
--- a/bosh/bosh_manifest.go
+++ b/bosh/bosh_manifest.go
@@ -23,6 +23,7 @@ type BoshManifest struct {
 	Update         Update                 `yaml:"update"`
 	Properties     map[string]interface{} `yaml:"properties,omitempty"`
 	Variables      []Variable             `yaml:"variables,omitempty"`
+	Tags           map[string]interface{} `yaml:"tags,omitempty"`
 }
 
 type Variable struct {

--- a/bosh/bosh_manifest_test.go
+++ b/bosh/bosh_manifest_test.go
@@ -129,6 +129,10 @@ var _ = Describe("de(serialising) BOSH manifests", func() {
 				},
 			},
 		},
+		Tags: map[string]interface{}{
+			"quadrata": "parrot",
+			"secondTag" : "tagValue",
+		},
 	}
 
 	It("serialises bosh manifests", func() {
@@ -164,6 +168,7 @@ var _ = Describe("de(serialising) BOSH manifests", func() {
 				MaxInFlight:     4,
 			},
 			Variables: []bosh.Variable{},
+			Tags: map[string]interface{}{},
 		}
 
 		content, err := yaml.Marshal(emptyManifest)
@@ -181,6 +186,7 @@ var _ = Describe("de(serialising) BOSH manifests", func() {
 		Expect(content).NotTo(ContainSubstring("serial:"))
 		Expect(content).NotTo(ContainSubstring("variables:"))
 		Expect(content).NotTo(ContainSubstring("migrated_from:"))
+		Expect(content).NotTo(ContainSubstring("tags:"))
 	})
 
 	It("omits optional options from Variables", func() {

--- a/bosh/fixtures/manifest.yml
+++ b/bosh/fixtures/manifest.yml
@@ -61,3 +61,6 @@ update:
   update_watch_time: 30000-180000
   max_in_flight: 4
   serial: false
+tags:
+  quadrata: parrot
+  secondTag: tagValue


### PR DESCRIPTION
Hi,

We need support for the `tags` section of the Bosh Manifest when generated by our service adapter via ODB.

This adds in support.

Thanks,
