### PR TITLE
Respect symbols in properties

### DIFF
--- a/serviceadapter/command_line_handler.go
+++ b/serviceadapter/command_line_handler.go
@@ -160,7 +160,7 @@ func (p commandLineHandler) generateManifest(serviceDeploymentJSON, planJSON, ar
 		fail("error marshalling bosh manifest: %s", err)
 	}
 
-	fmt.Fprintf(os.Stdout, string(manifestBytes))
+	fmt.Fprint(os.Stdout, string(manifestBytes))
 }
 
 func (p commandLineHandler) createBinding(bindingID, boshVMsJSON, manifestYAML, requestParams string) {

--- a/serviceadapter/command_line_handler_test.go
+++ b/serviceadapter/command_line_handler_test.go
@@ -101,7 +101,16 @@ var (
 				OS:      "Windows",
 				Version: "3.1",
 			},
-		}}
+		},
+		InstanceGroups: []bosh.InstanceGroup{
+			{
+				Name: "Test",
+				Properties: map[string]interface{}{
+					"parseSymbols": "yes%[===",
+				},
+			},
+		},
+	}
 
 	expectedPreviousPlan = serviceadapter.Plan{
 		InstanceGroups: []serviceadapter.InstanceGroup{{

--- a/serviceadapter/testharness/main.go
+++ b/serviceadapter/testharness/main.go
@@ -114,7 +114,16 @@ func (m *manifestGenerator) GenerateManifest(serviceDeployment serviceadapter.Se
 				OS:      "Windows",
 				Version: "3.1",
 			},
-		}}, nil
+		},
+		InstanceGroups: []bosh.InstanceGroup{
+			{
+				Name: "Test",
+				Properties: map[string]interface{}{
+					"parseSymbols": "yes%[===",
+				},
+			},
+		},
+	}, nil
 }
 
 func jsonSerialiseToFile(filePath string, obj interface{}) error {


### PR DESCRIPTION
There was unnecessary Fprintf in manifest output that corrupted symbols in the manifest.
This PR fixes this issue