### PR TITLE
Add VmStrategy to Update block

### DIFF
--- a/bosh/bosh_manifest.go
+++ b/bosh/bosh_manifest.go
@@ -106,6 +106,7 @@ type Update struct {
 	UpdateWatchTime string           `yaml:"update_watch_time"`
 	MaxInFlight     MaxInFlightValue `yaml:"max_in_flight"`
 	Serial          *bool            `yaml:"serial,omitempty"`
+	VmStrategy      string           `yaml:"vm_strategy,omitempty"`
 }
 
 type updateAlias Update

--- a/bosh/bosh_manifest_test.go
+++ b/bosh/bosh_manifest_test.go
@@ -135,6 +135,7 @@ var _ = Describe("(de)serialising BOSH manifests", func() {
 			UpdateWatchTime: "30000-180000",
 			MaxInFlight:     4,
 			Serial:          boolPointer(false),
+			VmStrategy:      "create-and-swap",
 		},
 		Variables: []bosh.Variable{
 			bosh.Variable{
@@ -230,6 +231,7 @@ var _ = Describe("(de)serialising BOSH manifests", func() {
 		Expect(content).NotTo(ContainSubstring("migrated_from:"))
 		Expect(content).NotTo(ContainSubstring("tags:"))
 		Expect(content).NotTo(ContainSubstring("features:"))
+		Expect(content).NotTo(ContainSubstring("vm_strategy:"))
 		Expect(strings.Count(string(content), "update:")).To(Equal(1))
 	})
 

--- a/bosh/fixtures/manifest.yml
+++ b/bosh/fixtures/manifest.yml
@@ -74,6 +74,7 @@ update:
   update_watch_time: 30000-180000
   max_in_flight: 4
   serial: false
+  vm_strategy: create-and-swap
 tags:
   quadrata: parrot
   secondTag: tagValue


### PR DESCRIPTION
This allows using the bosh hot-swap feature supported by recent bosh directors.