### PR TITLE
Add support for BOSH Configs

### DIFF
--- a/integration_tests/testharness/main.go
+++ b/integration_tests/testharness/main.go
@@ -51,7 +51,8 @@ func (m *manifestGenerator) GenerateManifest(
 	requestParams serviceadapter.RequestParameters,
 	previousManifest *bosh.BoshManifest,
 	previousPlan *serviceadapter.Plan,
-	previousSecrets serviceadapter.ManifestSecrets) (serviceadapter.GenerateManifestOutput, error) {
+	previousSecrets serviceadapter.ManifestSecrets,
+	previousConfigs serviceadapter.BOSHConfigs) (serviceadapter.GenerateManifestOutput, error) {
 
 	if os.Getenv(testvariables.OperationFailsKey) == OperationShouldFail {
 		fmt.Fprintf(os.Stderr, "not valid")

--- a/serviceadapter/domain.go
+++ b/serviceadapter/domain.go
@@ -31,7 +31,7 @@ import (
 
 //go:generate counterfeiter -o fakes/manifest_generator.go . ManifestGenerator
 type ManifestGenerator interface {
-	GenerateManifest(serviceDeployment ServiceDeployment, plan Plan, requestParams RequestParameters, previousManifest *bosh.BoshManifest, previousPlan *Plan, previousSecrets ManifestSecrets) (GenerateManifestOutput, error)
+	GenerateManifest(serviceDeployment ServiceDeployment, plan Plan, requestParams RequestParameters, previousManifest *bosh.BoshManifest, previousPlan *Plan, previousSecrets ManifestSecrets, previousConfigs BOSHConfigs) (GenerateManifestOutput, error)
 }
 
 //go:generate counterfeiter -o fakes/binder.go . Binder
@@ -82,6 +82,7 @@ type GenerateManifestParams struct {
 	PreviousManifest  string `json:"previous_manifest"`
 	RequestParameters string `json:"request_parameters"`
 	PreviousSecrets   string `json:"previous_secrets"`
+	PreviousConfigs   string `json:"previous_configs"`
 }
 
 type DashboardUrlParams struct {
@@ -121,15 +122,18 @@ type InputParams struct {
 }
 
 type ODBManagedSecrets map[string]interface{}
+type BOSHConfigs map[string]string
 
 type GenerateManifestOutput struct {
 	Manifest          bosh.BoshManifest `json:"manifest"`
 	ODBManagedSecrets ODBManagedSecrets `json:"secrets"`
+	Configs           BOSHConfigs       `json:"configs"`
 }
 
 type MarshalledGenerateManifest struct {
 	Manifest          string            `json:"manifest"`
 	ODBManagedSecrets ODBManagedSecrets `json:"secrets"`
+	Configs           BOSHConfigs       `json:"configs"`
 }
 
 const (

--- a/serviceadapter/fakes/manifest_generator.go
+++ b/serviceadapter/fakes/manifest_generator.go
@@ -9,7 +9,7 @@ import (
 )
 
 type FakeManifestGenerator struct {
-	GenerateManifestStub        func(serviceadapter.ServiceDeployment, serviceadapter.Plan, serviceadapter.RequestParameters, *bosh.BoshManifest, *serviceadapter.Plan, serviceadapter.ManifestSecrets) (serviceadapter.GenerateManifestOutput, error)
+	GenerateManifestStub        func(serviceadapter.ServiceDeployment, serviceadapter.Plan, serviceadapter.RequestParameters, *bosh.BoshManifest, *serviceadapter.Plan, serviceadapter.ManifestSecrets, serviceadapter.BOSHConfigs) (serviceadapter.GenerateManifestOutput, error)
 	generateManifestMutex       sync.RWMutex
 	generateManifestArgsForCall []struct {
 		arg1 serviceadapter.ServiceDeployment
@@ -18,6 +18,7 @@ type FakeManifestGenerator struct {
 		arg4 *bosh.BoshManifest
 		arg5 *serviceadapter.Plan
 		arg6 serviceadapter.ManifestSecrets
+		arg7 serviceadapter.BOSHConfigs
 	}
 	generateManifestReturns struct {
 		result1 serviceadapter.GenerateManifestOutput
@@ -31,7 +32,7 @@ type FakeManifestGenerator struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeManifestGenerator) GenerateManifest(arg1 serviceadapter.ServiceDeployment, arg2 serviceadapter.Plan, arg3 serviceadapter.RequestParameters, arg4 *bosh.BoshManifest, arg5 *serviceadapter.Plan, arg6 serviceadapter.ManifestSecrets) (serviceadapter.GenerateManifestOutput, error) {
+func (fake *FakeManifestGenerator) GenerateManifest(arg1 serviceadapter.ServiceDeployment, arg2 serviceadapter.Plan, arg3 serviceadapter.RequestParameters, arg4 *bosh.BoshManifest, arg5 *serviceadapter.Plan, arg6 serviceadapter.ManifestSecrets, arg7 serviceadapter.BOSHConfigs) (serviceadapter.GenerateManifestOutput, error) {
 	fake.generateManifestMutex.Lock()
 	ret, specificReturn := fake.generateManifestReturnsOnCall[len(fake.generateManifestArgsForCall)]
 	fake.generateManifestArgsForCall = append(fake.generateManifestArgsForCall, struct {
@@ -41,11 +42,12 @@ func (fake *FakeManifestGenerator) GenerateManifest(arg1 serviceadapter.ServiceD
 		arg4 *bosh.BoshManifest
 		arg5 *serviceadapter.Plan
 		arg6 serviceadapter.ManifestSecrets
-	}{arg1, arg2, arg3, arg4, arg5, arg6})
-	fake.recordInvocation("GenerateManifest", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
+		arg7 serviceadapter.BOSHConfigs
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("GenerateManifest", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	fake.generateManifestMutex.Unlock()
 	if fake.GenerateManifestStub != nil {
-		return fake.GenerateManifestStub(arg1, arg2, arg3, arg4, arg5, arg6)
+		return fake.GenerateManifestStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -60,17 +62,17 @@ func (fake *FakeManifestGenerator) GenerateManifestCallCount() int {
 	return len(fake.generateManifestArgsForCall)
 }
 
-func (fake *FakeManifestGenerator) GenerateManifestCalls(stub func(serviceadapter.ServiceDeployment, serviceadapter.Plan, serviceadapter.RequestParameters, *bosh.BoshManifest, *serviceadapter.Plan, serviceadapter.ManifestSecrets) (serviceadapter.GenerateManifestOutput, error)) {
+func (fake *FakeManifestGenerator) GenerateManifestCalls(stub func(serviceadapter.ServiceDeployment, serviceadapter.Plan, serviceadapter.RequestParameters, *bosh.BoshManifest, *serviceadapter.Plan, serviceadapter.ManifestSecrets, serviceadapter.BOSHConfigs) (serviceadapter.GenerateManifestOutput, error)) {
 	fake.generateManifestMutex.Lock()
 	defer fake.generateManifestMutex.Unlock()
 	fake.GenerateManifestStub = stub
 }
 
-func (fake *FakeManifestGenerator) GenerateManifestArgsForCall(i int) (serviceadapter.ServiceDeployment, serviceadapter.Plan, serviceadapter.RequestParameters, *bosh.BoshManifest, *serviceadapter.Plan, serviceadapter.ManifestSecrets) {
+func (fake *FakeManifestGenerator) GenerateManifestArgsForCall(i int) (serviceadapter.ServiceDeployment, serviceadapter.Plan, serviceadapter.RequestParameters, *bosh.BoshManifest, *serviceadapter.Plan, serviceadapter.ManifestSecrets, serviceadapter.BOSHConfigs) {
 	fake.generateManifestMutex.RLock()
 	defer fake.generateManifestMutex.RUnlock()
 	argsForCall := fake.generateManifestArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
 }
 
 func (fake *FakeManifestGenerator) GenerateManifestReturns(result1 serviceadapter.GenerateManifestOutput, result2 error) {

--- a/serviceadapter/generate_manifest.go
+++ b/serviceadapter/generate_manifest.go
@@ -108,7 +108,14 @@ func (g *GenerateManifestAction) Execute(inputParams InputParams, outputWriter i
 		}
 	}
 
-	generateManifestOutput, err := g.manifestGenerator.GenerateManifest(serviceDeployment, plan, requestParams, previousManifest, previousPlan, previousSecrets)
+	var previousConfigs BOSHConfigs
+	if generateManifestParams.PreviousConfigs != "" {
+		if err = json.Unmarshal([]byte(generateManifestParams.PreviousConfigs), &previousConfigs); err != nil {
+			return errors.Wrap(err, "unmarshalling previous configs")
+		}
+	}
+
+	generateManifestOutput, err := g.manifestGenerator.GenerateManifest(serviceDeployment, plan, requestParams, previousManifest, previousPlan, previousSecrets, previousConfigs)
 	if err != nil {
 		fmt.Fprintf(outputWriter, err.Error())
 		return CLIHandlerError{ErrorExitCode, err.Error()}

--- a/serviceadapter/serviceadapter_suite_test.go
+++ b/serviceadapter/serviceadapter_suite_test.go
@@ -143,6 +143,14 @@ func defaultPreviousManifest() bosh.BoshManifest {
 	}
 }
 
+func defaultPreviousBoshConfigs() serviceadapter.BOSHConfigs {
+	return serviceadapter.BOSHConfigs{
+		"cloud-config":   "fake-cloud-config",
+		"cpi-config":     "fake-cpi-config",
+		"runtime-config": "fake-runtime-config",
+	}
+}
+
 type CLIErrorMatcher struct {
 	exitCode       int
 	errorSubstring string


### PR DESCRIPTION
This commit adds support for Service Adapters to being able to generate BOSH Configs on-demand. It updates the GenerateManifest interface to be able to return a map of configs as part of the response, and to send old BOSH configs as part of the request.