### PR TITLE
Add "operation" package that allows DSL-like manipulation of a bosh.BoshManifest

### DIFF
--- a/operation/add_job_property.go
+++ b/operation/add_job_property.go
@@ -1,0 +1,42 @@
+package operation
+
+import (
+	"strings"
+)
+
+// The method takes a yml path in the form of a unix path and
+// any arbitrary value. The null check for o.job is explicitly
+// omitted for brevity.
+//
+// Ex. AddJobProperty("gemfire/tls/enabled", true)
+// gemfire:
+//   tls:
+//      enabled: true
+//
+// Ex. AddJobProperty("gemfire/name=tls/enabled", true)
+// gemfire:
+//   - name: tls
+//     enabled: true
+func (o *Operation) AddJobProperty(path string, value interface{}) *Operation {
+	if o.error != nil {
+		return o
+	}
+
+	entries := strings.Split(path, "/")
+
+	o.error = o.FetchJobProperty(func(props interface{}) error {
+		switch ps := props.(type) {
+		case map[string]interface{}:
+			ps[entries[len(entries)-1]] = value
+		case map[interface{}]interface{}:
+			ps[entries[len(entries)-1]] = value
+			// case []interface{}: is also possible
+			// but we haven't had reason to build this
+			// functionality (nor an error case) out yet.
+		}
+
+		return nil
+	}, entries, path, true)
+
+	return o
+}

--- a/operation/add_job_property_test.go
+++ b/operation/add_job_property_test.go
@@ -1,0 +1,167 @@
+package operation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	"github.com/pivotal-cf/on-demand-services-sdk/operation"
+)
+
+var _ = Describe("AddJobProperty", func() {
+	Context("when the job is present in the manifest", func() {
+		It("add the property to the job", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+					}},
+				}},
+			}
+
+			operation.New(manifest).
+				FindJob("gemfire-locator").
+				AddJobProperty("gemfire", true)
+
+			Expect(manifest.InstanceGroups[0].Jobs[0].Properties).To(HaveKeyWithValue("gemfire", true))
+		})
+	})
+
+	Context("when the job is present in the manifest and nested paths are specified", func() {
+		It("add the property to the job", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+					}},
+				}},
+			}
+
+			operation.New(manifest).
+				FindJob("gemfire-locator").
+				AddJobProperty("gemfire/tls/enabled", true)
+
+			Expect(manifest.InstanceGroups[0].Jobs[0].Properties).To(Equal(map[string]interface{}{
+				"gemfire": map[interface{}]interface{}{
+					"tls": map[interface{}]interface{}{
+						"enabled": true,
+					},
+				},
+			}))
+		})
+	})
+
+	Context("when the job is present in the manifest and path query is specified", func() {
+		It("add the property to the job", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name":                  "cloudcache",
+										"port":                  8080,
+										"registration_interval": "20s",
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			err := operation.New(manifest).
+				FindJob("route_registrar").
+				AddJobProperty("route_registrar/routes/name=cloudcache/some_key", "some_value").
+				Error()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(manifest.InstanceGroups[0].Jobs[0].Properties).To(Equal(map[string]interface{}{
+				"route_registrar": map[interface{}]interface{}{
+					"routes": []interface{}{
+						map[interface{}]interface{}{
+							"name":                  "cloudcache",
+							"port":                  8080,
+							"registration_interval": "20s",
+							"some_key":              "some_value",
+						},
+					},
+				},
+			}))
+		})
+	})
+
+	Context("when the job is present in the manifest and an incorrect path query is specified", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name":                  "cloudcache",
+										"port":                  8080,
+										"registration_interval": "20s",
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			err := operation.New(manifest).
+				FindJob("route_registrar").
+				AddJobProperty("route_registrar/routes/name=some-incorrect-property/some_key", "some_value").
+				Error()
+			Expect(err).To(MatchError(ContainSubstring("failed match 'name=some-incorrect-property' of 'route_registrar/routes/name=some-incorrect-property/some_key' in:")))
+		})
+	})
+
+	Context("when the job is present in the manifest and path already exists but is not a mapping", func() {
+		It("fails with a helpful error message ", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+						Properties: map[string]interface{}{
+							"gemfire": map[interface{}]interface{}{
+								"tls": 12,
+							},
+						},
+					}},
+				}},
+			}
+
+			err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				AddJobProperty("gemfire/tls/enabled", true).
+				Error()
+
+			Expect(err).To(MatchError("failed to apply property at 'gemfire/tls/enabled' because '12'(int) exists at .tls"))
+		})
+	})
+
+	Context("when the operation already has an error", func() {
+		It("returns the error message and performs no other steps", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+					}},
+				}},
+			}
+
+			err := operation.New(manifest).
+				FindJob("some-incorrect-job-name").
+				AddJobProperty("gemfire", true).
+				Error()
+
+			Expect(err).To(MatchError("failed to find job 'some-incorrect-job-name' within manifest"))
+			Expect(manifest.InstanceGroups[0].Jobs[0].Properties).To(BeEmpty())
+		})
+	})
+})

--- a/operation/add_variable.go
+++ b/operation/add_variable.go
@@ -1,0 +1,35 @@
+package operation
+
+import (
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	"fmt"
+)
+
+// Convenience method to add bosh.Variables to the manifest.
+// An error with loaded if the variable already exists.
+func (o *Operation) AddVariables(variables ...bosh.Variable) *Operation {
+	if o.error != nil {
+		return o
+	}
+
+	alreadyExists := func(variable bosh.Variable) bool {
+		for _, v := range o.manifest.Variables {
+			if v.Name == variable.Name {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for _, variable := range variables {
+		if alreadyExists(variable) {
+			o.error = fmt.Errorf("failed to add bosh.Variable '%s' because it is already present", variable.Name)
+			return o
+		}
+
+		o.manifest.Variables = append(o.manifest.Variables, variable)
+	}
+
+	return o
+}

--- a/operation/add_variable_test.go
+++ b/operation/add_variable_test.go
@@ -1,0 +1,71 @@
+package operation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	"github.com/pivotal-cf/on-demand-services-sdk/operation"
+)
+
+var _ = Describe("AddVariables", func() {
+	Context("when the variables do not exist", func() {
+		It("add variables to the manifest", func() {
+			manifest := &bosh.BoshManifest{}
+
+			operation.New(manifest).
+				AddVariables(
+					bosh.Variable{Name: "some-variable-1", Type: "password"},
+					bosh.Variable{Name: "some-variable-2", Type: "certificate"},
+				)
+
+			Expect(manifest.Variables).To(Equal([]bosh.Variable{
+				{Name: "some-variable-1", Type: "password"},
+				{Name: "some-variable-2", Type: "certificate"},
+			}))
+		})
+	})
+
+	Context("when a variable already exists in the manifest", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{}
+
+			operation.New(manifest).
+				AddVariables(bosh.Variable{Name: "some-variable-1", Type: "password"})
+
+			err := operation.New(manifest).
+				AddVariables(bosh.Variable{Name: "some-variable-1", Type: "certificate"}).
+				Error()
+
+			Expect(err).To(MatchError("failed to add bosh.Variable 'some-variable-1' because it is already present"))
+		})
+	})
+
+	Context("when a variable already exists in the method call", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{}
+
+			err := operation.New(manifest).
+				AddVariables(
+					bosh.Variable{Name: "some-variable-1", Type: "password"},
+					bosh.Variable{Name: "some-variable-1", Type: "certificate"},
+				).
+				Error()
+
+			Expect(err).To(MatchError("failed to add bosh.Variable 'some-variable-1' because it is already present"))
+		})
+	})
+
+	Context("when the operation already has an error", func() {
+		It("returns the error message and performs no other steps", func() {
+			manifest := &bosh.BoshManifest{}
+
+			err := operation.New(manifest).
+				FindJob("some-incorrect-job-name").
+				AddVariables(bosh.Variable{Name: "some-variable-1", Type: "password"}).
+				Error()
+
+			Expect(err).To(MatchError("failed to find job 'some-incorrect-job-name' within manifest"))
+			Expect(manifest.Variables).To(BeEmpty())
+		})
+	})
+})

--- a/operation/do_job_action.go
+++ b/operation/do_job_action.go
@@ -1,0 +1,20 @@
+package operation
+
+import (
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+)
+
+// Perform an action on the job. Useful for making use
+// of provided odb sdk action. The null check for o.job is explicitly
+// omitted for brevity.
+func (o *Operation) DoJobAction(action func(int, *bosh.Job)) *Operation {
+	if o.error != nil {
+		return o
+	}
+
+	for i, job := range o.jobs {
+		action(i, job)
+	}
+
+	return o
+}

--- a/operation/do_job_action_test.go
+++ b/operation/do_job_action_test.go
@@ -1,0 +1,67 @@
+package operation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	"github.com/pivotal-cf/on-demand-services-sdk/operation"
+)
+
+var _ = Describe("DoJobAction", func() {
+	Context("when the job is present in the manifest", func() {
+		It("performs the job action", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{
+					{
+						Name: "some-instance-group-1",
+						Jobs: []bosh.Job{{
+							Name: "gemfire-locator",
+						}},
+					},
+					{
+						Name: "some-instance-group-2",
+						Jobs: []bosh.Job{{
+							Name: "gemfire-locator",
+						}},
+					},
+				},
+			}
+
+			operation.New(manifest).
+				FindJob("gemfire-locator").
+				DoJobAction(func(i int, job *bosh.Job) {
+					job.Provides = map[string]bosh.ProvidesLink{
+						"gemfire-locator-address": {Shared: true},
+					}
+				})
+
+			Expect(manifest.InstanceGroups[0].Jobs[0].Provides).To(Equal(map[string]bosh.ProvidesLink{
+				"gemfire-locator-address": {Shared: true},
+			}))
+			Expect(manifest.InstanceGroups[1].Jobs[0].Provides).To(Equal(map[string]bosh.ProvidesLink{
+				"gemfire-locator-address": {Shared: true},
+			}))
+		})
+	})
+
+	Context("when the operation already has an error", func() {
+		It("returns the error message and performs no other steps", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+					}},
+				}},
+			}
+
+			err := operation.New(manifest).
+				FindJob("some-incorrect-job-name").
+				DoJobAction(func(i int, job *bosh.Job) {
+					Fail("this step should not be reached")
+				}).
+				Error()
+
+			Expect(err).To(MatchError("failed to find job 'some-incorrect-job-name' within manifest"))
+		})
+	})
+})

--- a/operation/each_instance_group.go
+++ b/operation/each_instance_group.go
@@ -1,0 +1,18 @@
+package operation
+
+import "github.com/pivotal-cf/on-demand-services-sdk/bosh"
+
+// Perform an action on each instance group. Useful for making use
+// of provided odb sdk action.
+func (o *Operation) EachInstanceGroup(action func(*bosh.InstanceGroup)) *Operation {
+	if o.error != nil {
+		return o
+	}
+
+	for i, _ := range o.manifest.InstanceGroups {
+		action(&o.manifest.InstanceGroups[i])
+	}
+
+	return o
+}
+

--- a/operation/each_instance_group_test.go
+++ b/operation/each_instance_group_test.go
@@ -1,0 +1,51 @@
+package operation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	"github.com/pivotal-cf/on-demand-services-sdk/operation"
+)
+
+var _ = Describe("EachInstanceGroup", func() {
+	Context("By default", func() {
+		It("performs an action on each instance group", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{
+					{Name: "some-instance-group-1"},
+					{Name: "some-instance-group-2"},
+				},
+			}
+
+			operation.New(manifest).
+				EachInstanceGroup(func(ig *bosh.InstanceGroup) {
+					ig.Name = "some-modified-instance-group"
+				})
+
+			Expect(manifest.InstanceGroups[0].Name).To(Equal("some-modified-instance-group"))
+			Expect(manifest.InstanceGroups[1].Name).To(Equal("some-modified-instance-group"))
+		})
+	})
+
+	Context("when the operation already has an error", func() {
+		It("returns the error message and performs no other steps", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{
+					{Name: "some-instance-group-1"},
+					{Name: "some-instance-group-2"},
+				},
+			}
+
+			err := operation.New(manifest).
+				FindJob("some-incorrect-job-name").
+				EachInstanceGroup(func(ig *bosh.InstanceGroup) {
+					ig.Name = "some-modified-instance-group"
+				}).
+				Error()
+
+			Expect(err).To(MatchError("failed to find job 'some-incorrect-job-name' within manifest"))
+			Expect(manifest.InstanceGroups[0].Name).To(Equal("some-instance-group-1"))
+			Expect(manifest.InstanceGroups[1].Name).To(Equal("some-instance-group-2"))
+		})
+	})
+})

--- a/operation/find_job.go
+++ b/operation/find_job.go
@@ -1,0 +1,29 @@
+package operation
+
+import "fmt"
+
+// FindJob() is a stateful method that loads a job onto
+// the Operations struct. It is useless by itself but
+// provides value when chaining update methods on the
+// retrieved job
+func (o *Operation) FindJob(name string) *Operation {
+	if o.error != nil {
+		return o
+	}
+
+	o.jobs = nil
+
+	for _, ig := range o.manifest.InstanceGroups {
+		for i, job := range ig.Jobs {
+			if job.Name == name {
+				o.jobs = append(o.jobs, &ig.Jobs[i])
+			}
+		}
+	}
+
+	if len(o.jobs) == 0 {
+		o.error = fmt.Errorf("failed to find job '%s' within manifest", name)
+	}
+
+	return o
+}

--- a/operation/find_job_test.go
+++ b/operation/find_job_test.go
@@ -1,0 +1,90 @@
+package operation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	"github.com/pivotal-cf/on-demand-services-sdk/operation"
+)
+
+var _ = Describe("FindJob", func() {
+	Context("when the job is present in the manifest", func() {
+		It("loads the job and returns no error", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+					}},
+				}},
+			}
+
+			err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				Error()
+
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when the job is not present in the manifest", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "some-incorrect-bosh-job",
+					}},
+				}},
+			}
+
+			err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				Error()
+
+			Expect(err).To(MatchError("failed to find job 'gemfire-locator' within manifest"))
+		})
+	})
+
+	Context("when the operation already has an error", func() {
+		It("returns the error message and performs no other steps", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "some-incorrect-bosh-job",
+					}},
+				}},
+			}
+
+			err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				FindJob("gemfire-server").
+				FindJob("gemfire-healthcheck").
+				Error()
+
+			Expect(err).To(MatchError("failed to find job 'gemfire-locator' within manifest"))
+		})
+	})
+
+	Context("when FindJob is called successively", func() {
+		It("subsequent operation commands only affect latest 'Found' job", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{
+						{Name: "gemfire-locator"},
+						{Name: "gemfire-server"},
+					},
+				}},
+			}
+
+			operation.New(manifest).
+				FindJob("gemfire-locator").
+				FindJob("gemfire-server").
+				DoJobAction(func(i int, job *bosh.Job) {
+					job.Name = "some-changed-job-name"
+				})
+
+			Expect(manifest.InstanceGroups[0].Jobs[0].Name).To(Equal("gemfire-locator"))
+			Expect(manifest.InstanceGroups[0].Jobs[1].Name).To(Equal("some-changed-job-name"))
+		})
+	})
+
+})

--- a/operation/get_job_property_int.go
+++ b/operation/get_job_property_int.go
@@ -1,0 +1,89 @@
+package operation
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// The method takes a yml path in the form of a unix path and
+// any arbitrary value. The null check for o.job is explicitly
+// omitted for brevity.
+//
+// Ex. GetJobPropertyInt("gemfire/tls/enabled")
+// gemfire:
+//   tls:
+//      enabled: 123
+//
+// Ex. GetJobPropertyInt("gemfire/name=tls/enabled")
+// gemfire:
+//   - name: tls
+//     enabled: 123
+func (o *Operation) GetJobPropertyInt(path string) (int, error) {
+	if o.error != nil {
+		return 0, o.error
+	}
+
+	if len(o.jobs) > 1 {
+		return 0, errors.New("failed to execute 'GetJobPropertyInt': not implemented for cases where multiple jobs are retrieved")
+	}
+
+	var (
+		result  int
+		entries = strings.Split(path, "/")
+	)
+
+	err := o.FetchJobProperty(func(props interface{}) error {
+		var err error
+		result, err = o.getJobPropertyInt(props, entries, path)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, entries, path)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return result, nil
+}
+
+func (o *Operation) getJobPropertyInt(props interface{}, entries []string, path string) (int, error) {
+	switch ps := props.(type) {
+	case map[string]interface{}:
+		value := ps[entries[len(entries)-1]]
+		v, ok := value.(int)
+		if !ok {
+			return 0, fmt.Errorf("failed to find int value at '%s', instead '%v'(%T) was found", path, value, value)
+		}
+
+		return v, nil
+	case map[interface{}]interface{}:
+		value := ps[entries[len(entries)-1]]
+		v, ok := value.(int)
+		if !ok {
+			return 0, fmt.Errorf("failed to find int value at '%s', instead '%v'(%T) was found", path, value, value)
+		}
+
+		return v, nil
+	case []interface{}:
+		value, err := handleIndexingArrayInterface(entries, path, ps)
+		if err != nil {
+			return 0, err
+		}
+
+		v, ok := value.(int)
+		if !ok {
+			return 0, fmt.Errorf("failed to find int value at '%s', instead '%v'(%T) was found", path, value, value)
+		}
+
+		return v, nil
+	default:
+		// Due to the how fetchJobProperty() works, this code should never be reached
+		// presumably...
+		return 0, fmt.Errorf("failed to find a supported structure at '%s', instead '%v'(%T) was found", path, props, props)
+	}
+
+}

--- a/operation/get_job_property_int_test.go
+++ b/operation/get_job_property_int_test.go
@@ -1,0 +1,303 @@
+package operation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	"github.com/pivotal-cf/on-demand-services-sdk/operation"
+)
+
+var _ = Describe("GetJobPropertyInt", func() {
+	Context("when the job is present in the manifest and nested paths are specified", func() {
+		It("fetches the property as an int", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+						Properties: map[string]interface{}{
+							"gemfire": map[interface{}]interface{}{
+								"tls": map[interface{}]interface{}{
+									"enabled": 123,
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			result, err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				GetJobPropertyInt("gemfire/tls/enabled")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(123))
+		})
+	})
+
+	Context("when the job is present in the manifest and path query is specified", func() {
+		It("fetches the property as an int", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name":                  "cloudcache",
+										"port":                  8080,
+										"registration_interval": 20,
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			result, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyInt("route_registrar/routes/name=cloudcache/registration_interval")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(20))
+		})
+	})
+
+	Context("when the job is present in the manifest and a trailing path index is specified", func() {
+		It("fetches the property as an int", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name":                   "cloudcache",
+										"port":                   8080,
+										"registration_intervals": []interface{}{10, 20},
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			result, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyInt("route_registrar/routes/name=cloudcache/registration_intervals/1")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(20))
+		})
+	})
+
+	Context("when the job is present in the manifest and a trailing path index is specified but there's no int", func() {
+		It("returns an error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name":                   "cloudcache",
+										"port":                   8080,
+										"registration_intervals": []interface{}{"some-value-1", "some-value-2"},
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyInt("route_registrar/routes/name=cloudcache/registration_intervals/1")
+
+			Expect(err).To(MatchError("failed to find int value at 'route_registrar/routes/name=cloudcache/registration_intervals/1', instead 'some-value-2'(string) was found"))
+		})
+	})
+
+	Context("when the job is present in the manifest and there is no trailing path for array", func() {
+		It("returns an error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name":                   "cloudcache",
+										"port":                   8080,
+										"registration_intervals": []interface{}{10, 20},
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyInt("route_registrar/routes/name=cloudcache/registration_intervals/100")
+
+			Expect(err).To(MatchError(MatchRegexp("failed to find value at 'route_registrar/routes/name=cloudcache/registration_intervals/100', because .* only has 2 values")))
+		})
+	})
+
+	Context("when the job is present in the manifest and there is no trailing path for array", func() {
+		It("returns an error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name":                   "cloudcache",
+										"port":                   8080,
+										"registration_intervals": []interface{}{10, 20},
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyInt("route_registrar/routes/name=cloudcache/registration_intervals/some-non-digit-key")
+
+			Expect(err).To(MatchError(MatchRegexp("failed to find value at 'route_registrar/routes/name=cloudcache/registration_intervals/some-non-digit-key', because .* was found but a non-digit was specified at .some-non-digit-key")))
+		})
+	})
+
+	Context("when the job is present in the manifest and an incorrect path query is specified", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name":                  "cloudcache",
+										"port":                  8080,
+										"registration_interval": "20s",
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyInt("route_registrar/routes/name=some-incorrect-property/some_key")
+
+			Expect(err).To(MatchError(ContainSubstring("failed match 'name=some-incorrect-property' of 'route_registrar/routes/name=some-incorrect-property/some_key' in:")))
+		})
+	})
+
+	Context("when the job is present in the manifest and path query is specified but the type is not a string", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+						Properties: map[string]interface{}{
+							"gemfire": map[interface{}]interface{}{
+								"tls": map[interface{}]interface{}{
+									"enabled": true,
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				GetJobPropertyInt("gemfire/tls/enabled")
+
+			Expect(err).To(MatchError("failed to find int value at 'gemfire/tls/enabled', instead 'true'(bool) was found"))
+		})
+	})
+
+	Context("when the job is not present in the manifest", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+						Properties: map[string]interface{}{
+							"gemfire": map[interface{}]interface{}{
+								"tls": map[interface{}]interface{}{
+									"enabled": 123,
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("some-incorrect-job").
+				GetJobPropertyInt("gemfire/tls/enabled")
+
+			Expect(err).To(MatchError("failed to find job 'some-incorrect-job' within manifest"))
+		})
+	})
+
+	Context("when multiple jobs are found for the given operation", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{
+					{
+						Name: "some-instance-group-1",
+						Jobs: []bosh.Job{{
+							Name: "gemfire-locator",
+							Properties: map[string]interface{}{
+								"gemfire": map[interface{}]interface{}{
+									"tls": map[interface{}]interface{}{
+										"enabled": 123,
+									},
+								},
+							},
+						}},
+					},
+					{
+						Name: "some-instance-group-2",
+						Jobs: []bosh.Job{{
+							Name: "gemfire-locator",
+							Properties: map[string]interface{}{
+								"gemfire": map[interface{}]interface{}{
+									"tls": map[interface{}]interface{}{
+										"enabled": 123,
+									},
+								},
+							},
+						}},
+					},
+				},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				GetJobPropertyInt("gemfire/tls/enabled")
+
+			Expect(err).To(MatchError("failed to execute 'GetJobPropertyInt': not implemented for cases where multiple jobs are retrieved"))
+		})
+	})
+})

--- a/operation/get_job_property_string.go
+++ b/operation/get_job_property_string.go
@@ -1,0 +1,88 @@
+package operation
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// The method takes a yml path in the form of a unix path and
+// any arbitrary value. The null check for o.job is explicitly
+// omitted for brevity.
+//
+// Ex. GetJobPropertyString("gemfire/tls/enabled")
+// gemfire:
+//   tls:
+//      enabled: "true"
+//
+// Ex. GetJobPropertyString("gemfire/name=tls/enabled")
+// gemfire:
+//   - name: tls
+//     enabled: true
+func (o *Operation) GetJobPropertyString(path string) (string, error) {
+	if o.error != nil {
+		return "", o.error
+	}
+
+	if len(o.jobs) > 1 {
+		return "", errors.New("failed to execute 'GetJobPropertyString': not implemented for cases where multiple jobs are retrieved")
+	}
+
+	var (
+		result  string
+		entries = strings.Split(path, "/")
+	)
+
+	err := o.FetchJobProperty(func(props interface{}) error {
+		var err error
+		result, err = o.getJobPropertyString(props, entries, path)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, entries, path)
+
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
+}
+
+func (o *Operation) getJobPropertyString(props interface{}, entries []string, path string) (string, error) {
+	switch ps := props.(type) {
+	case map[string]interface{}:
+		value := ps[entries[len(entries)-1]]
+		v, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("failed to find string value at '%s', instead '%v'(%T) was found", path, value, value)
+		}
+
+		return v, nil
+	case map[interface{}]interface{}:
+		value := ps[entries[len(entries)-1]]
+		v, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("failed to find string value at '%s', instead '%v'(%T) was found", path, value, value)
+		}
+
+		return v, nil
+	case []interface{}:
+		value, err := handleIndexingArrayInterface(entries, path, ps)
+		if err != nil {
+			return "", err
+		}
+
+		v, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("failed to find string value at '%s', instead '%v'(%T) was found", path, value, value)
+		}
+
+		return v, nil
+	default:
+		// Due to the how fetchJobProperty() works, this code should never be reached
+		// presumably...
+		return "", fmt.Errorf("failed to find a supported structure at '%s', instead '%v'(%T) was found", path, props, props)
+	}
+}

--- a/operation/get_job_property_string_test.go
+++ b/operation/get_job_property_string_test.go
@@ -1,0 +1,308 @@
+package operation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	"github.com/pivotal-cf/on-demand-services-sdk/operation"
+)
+
+var _ = Describe("GetJobPropertyString", func() {
+	Context("when the job is present in the manifest and nested paths are specified", func() {
+		It("fetches the property as a string", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+						Properties: map[string]interface{}{
+							"gemfire": map[interface{}]interface{}{
+								"tls": map[interface{}]interface{}{
+									"enabled": "true",
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			result, err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				GetJobPropertyString("gemfire/tls/enabled")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal("true"))
+		})
+	})
+
+	Context("when the job is present in the manifest and path query is specified", func() {
+		It("fetches the property as a string", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name": "cloudcache",
+										"port": 8080,
+										"registration_interval": "20s",
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			result, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyString("route_registrar/routes/name=cloudcache/registration_interval")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal("20s"))
+		})
+	})
+
+	Context("when the job is present in the manifest and a trailing path index is specified", func() {
+		It("fetches the property as a string", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name": "cloudcache",
+										"port": 8080,
+										"registration_interval": "20s",
+										"uris": []interface{}{"some-uri-1", "some-uri-2"},
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			result, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyString("route_registrar/routes/name=cloudcache/uris/1")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal("some-uri-2"))
+		})
+	})
+
+	Context("when the job is present in the manifest and a trailing path index is specified but there's no string", func() {
+		It("returns an error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name": "cloudcache",
+										"port": 8080,
+										"registration_interval": "20s",
+										"uris": []interface{}{123, 456},
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyString("route_registrar/routes/name=cloudcache/uris/1")
+
+			Expect(err).To(MatchError("failed to find string value at 'route_registrar/routes/name=cloudcache/uris/1', instead '456'(int) was found"))
+		})
+	})
+
+	Context("when the job is present in the manifest and there is no trailing path for array", func() {
+		It("returns an error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name": "cloudcache",
+										"port": 8080,
+										"registration_interval": "20s",
+										"uris": []interface{}{"some-uri-1", "some-uri-2"},
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyString("route_registrar/routes/name=cloudcache/uris/100")
+
+			Expect(err).To(MatchError(MatchRegexp("failed to find value at 'route_registrar/routes/name=cloudcache/uris/100', because .* only has 2 values")))
+		})
+	})
+
+	Context("when the job is present in the manifest and there is no trailing path for array", func() {
+		It("returns an error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name": "cloudcache",
+										"port": 8080,
+										"registration_interval": "20s",
+										"uris": []interface{}{"some-uri-1", "some-uri-2"},
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyString("route_registrar/routes/name=cloudcache/uris/some-non-digit-key")
+
+			Expect(err).To(MatchError(MatchRegexp("failed to find value at 'route_registrar/routes/name=cloudcache/uris/some-non-digit-key', because .* was found but a non-digit was specified at .some-non-digit-key")))
+		})
+	})
+
+	Context("when the job is present in the manifest and an incorrect path query is specified", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "route_registrar",
+						Properties: map[string]interface{}{
+							"route_registrar": map[interface{}]interface{}{
+								"routes": []interface{}{
+									map[interface{}]interface{}{
+										"name": "cloudcache",
+										"port": 8080,
+										"registration_interval": "20s",
+									},
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("route_registrar").
+				GetJobPropertyString("route_registrar/routes/name=some-incorrect-property/some_key")
+
+			Expect(err).To(MatchError(ContainSubstring("failed match 'name=some-incorrect-property' of 'route_registrar/routes/name=some-incorrect-property/some_key' in:")))
+		})
+	})
+
+	Context("when the job is present in the manifest and path query is specified but the type is not a string", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+						Properties: map[string]interface{}{
+							"gemfire": map[interface{}]interface{}{
+								"tls": map[interface{}]interface{}{
+									"enabled": true,
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				GetJobPropertyString("gemfire/tls/enabled")
+
+			Expect(err).To(MatchError("failed to find string value at 'gemfire/tls/enabled', instead 'true'(bool) was found"))
+		})
+	})
+
+	Context("when the job is not present in the manifest", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{{
+					Jobs: []bosh.Job{{
+						Name: "gemfire-locator",
+						Properties: map[string]interface{}{
+							"gemfire": map[interface{}]interface{}{
+								"tls": map[interface{}]interface{}{
+									"enabled": "true",
+								},
+							},
+						},
+					}},
+				}},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("some-incorrect-job").
+				GetJobPropertyString("gemfire/tls/enabled")
+
+			Expect(err).To(MatchError("failed to find job 'some-incorrect-job' within manifest"))
+		})
+	})
+
+
+	Context("when multiple jobs are found for the given operation", func() {
+		It("returns a helpful error message", func() {
+			manifest := &bosh.BoshManifest{
+				InstanceGroups: []bosh.InstanceGroup{
+					{
+						Name: "some-instance-group-1",
+						Jobs: []bosh.Job{{
+							Name: "gemfire-locator",
+							Properties: map[string]interface{}{
+								"gemfire": map[interface{}]interface{}{
+									"tls": map[interface{}]interface{}{
+										"enabled": "true",
+									},
+								},
+							},
+						}},
+					},
+					{
+						Name: "some-instance-group-2",
+						Jobs: []bosh.Job{{
+							Name: "gemfire-locator",
+							Properties: map[string]interface{}{
+								"gemfire": map[interface{}]interface{}{
+									"tls": map[interface{}]interface{}{
+										"enabled": "true",
+									},
+								},
+							},
+						}},
+					},
+				},
+			}
+
+			_, err := operation.New(manifest).
+				FindJob("gemfire-locator").
+				GetJobPropertyString("gemfire/tls/enabled")
+
+			Expect(err).To(MatchError("failed to execute 'GetJobPropertyString': not implemented for cases where multiple jobs are retrieved"))
+		})
+	})
+})

--- a/operation/job_property.go
+++ b/operation/job_property.go
@@ -1,0 +1,162 @@
+package operation
+
+import (
+	"fmt"
+	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	"regexp"
+	"strconv"
+)
+
+func (o *Operation) FetchJobProperty(handler func(interface{}) error, entries []string, path string, options ...bool) error {
+	for _, job := range o.jobs {
+		prop, err := o.fetchJobProperty(job, entries, path, options...)
+		if err != nil {
+			return err
+		}
+
+		err = handler(prop)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *Operation) fetchJobProperty(job *bosh.Job, entries []string, path string, options ...bool) (interface{}, error) {
+	autoContructMappings := len(options) > 0 && options[0] == true
+
+	if autoContructMappings && job.Properties == nil {
+		job.Properties = map[string]interface{}{}
+	}
+
+	var (
+		props   interface{} = job.Properties
+	)
+
+	for i := 0; i < len(entries)-1; i++ {
+		entry := entries[i]
+
+		switch ps := props.(type) {
+		case []interface{}:
+			v, err := handleArrayInterface(entry, path, ps)
+			if err != nil {
+				return nil, err
+			}
+
+			props = v
+		case map[string]interface{}:
+			if autoContructMappings && ps[entry] == nil {
+				ps[entry] = map[interface{}]interface{}{}
+			}
+
+			v := ps[entry]
+
+			if !isSupportedDatastructure(v) {
+				return nil, fmt.Errorf(
+					"failed to apply property at '%s' because '%v'(%T) exists at .%s",
+					path, v, v, entry)
+			}
+
+			props = v
+		case map[interface{}]interface{}:
+			if autoContructMappings && ps[entry] == nil {
+				ps[entry] = map[interface{}]interface{}{}
+			}
+
+			v := ps[entry]
+
+			if !isSupportedDatastructure(v) {
+				return nil, fmt.Errorf(
+					"failed to apply property at '%s' because '%v'(%T) exists at .%s",
+					path, v, v, entry)
+			}
+
+			props = v
+		}
+	}
+
+	return props, nil
+}
+
+func handleArrayInterface(entry string, path string, properties []interface{}) (interface{}, error) {
+	var (
+		// The only matches we support at this level is querying
+		// Ops files can also support indexing at this level
+		// Let's defer building that functionality until we need it
+		isQueryRegex = regexp.MustCompile(`(.+)=(.+)`)
+		matches      = isQueryRegex.FindStringSubmatch(entry)
+	)
+
+	if len(matches) != 3 {
+		return nil, fmt.Errorf(
+			"failed to apply property at '%s' because a query is needed for '%v'(%T) but '%s' was provided",
+			path, properties, properties, entry)
+	}
+
+	key := matches[1]
+	value := matches[2]
+
+	for _, object := range properties {
+		switch obj := object.(type) {
+		case map[string]interface{}:
+			for k, v := range obj {
+				if k == key && v == value {
+					return object, nil
+				}
+			}
+		case map[interface{}]interface{}:
+			for k, v := range obj {
+				if k == key && v == value {
+					return object, nil
+				}
+			}
+		}
+		// there is a minor concern here about catching cases don't match these types
+		// but that would be terrible yml for a BOSH manifest.
+		// We will handle it if we ever reach that problem
+	}
+
+	return nil, fmt.Errorf("failed match '%s' of '%s' in: %v", entry, path, properties)
+}
+
+func handleIndexingArrayInterface(entries []string, path string, properties []interface{}) (interface{}, error) {
+	var (
+		isDigitRegex = regexp.MustCompile(`(\d+)`)
+		value        = entries[len(entries)-1]
+		matches      = isDigitRegex.FindStringSubmatch(value)
+	)
+
+	if len(matches) != 2 {
+		return nil, fmt.Errorf("failed to find value at '%s', because '%v'(%T) was found but a non-digit was specified at .%s",
+			path, properties, properties, value)
+	}
+
+	digit, _ := strconv.Atoi(matches[1])
+
+	if len(properties) <= digit {
+		return nil, fmt.Errorf("failed to find value at '%s', because '%v'(%T) only has %d values",
+			path, properties, properties, len(properties))
+	}
+
+	return properties[digit], nil
+}
+
+func isSupportedDatastructure(value interface{}) bool {
+	if value == nil {
+		return false
+	}
+
+	_, ok := value.(map[string]interface{})
+	if ok {
+		return true
+	}
+
+	_, ok = value.(map[interface{}]interface{})
+	if ok {
+		return true
+	}
+
+	_, ok = value.([]interface{})
+	return ok
+}

--- a/operation/operation.go
+++ b/operation/operation.go
@@ -1,0 +1,19 @@
+package operation
+
+import "github.com/pivotal-cf/on-demand-services-sdk/bosh"
+
+type Operation struct {
+	error    error
+	manifest *bosh.BoshManifest
+	jobs     []*bosh.Job
+}
+
+func New(manifest *bosh.BoshManifest) *Operation {
+	return &Operation{
+		manifest: manifest,
+	}
+}
+
+func (o *Operation) Error() error {
+	return o.error
+}

--- a/operation/operation_suite_test.go
+++ b/operation/operation_suite_test.go
@@ -1,0 +1,13 @@
+package operation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOperation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operation Suite")
+}


### PR DESCRIPTION
Inclusion of this PR was fallout from **[CF-RFC] 025** and the most recent service-anchors meeting. Please see @aemengo or the RFC for more details.

```
Ex. return operation.New(manifest).
        AddVariables(variables...).
        FindJob("gemfire-locator").
          AddJobProperty("gemfire/tls", false).
          AddJobProperty("gemfire/truststore_password", "((trust-store-password))").
          AddJobProperty("gemfire/keystore_password", "((key-store-password))").
          AddJobProperty("gemfire/locator-certificate", "((gemfire-locator-certificate))").
          AddJobProperty("gemfire/trusted_certs", t.trustedCerts()).
        FindJob("gemfire-server").
          AddJobProperty("gemfire/server-certificate", "((gemfire-server-certificate))").
        FindJob("route_registrar").
          AddJobProperty("route_registrar/routes/name=cloudcache/server_cert_domain_san", uri).
          AddJobProperty("route_registrar/routes/name=cloudcache/tls_port", port).
        Error()
```

@dlresende @MirahImage 