### PR TITLE
drop support for go1.19

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.19', '1.20' ]
+        version: [ 'oldstable', 'stable' ]
     name: Go ${{ matrix.version }}
     outputs:
       pr_number: ${{ github.event.number }}
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.version }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: ./scripts/run-tests.sh
   call-dependabot-pr-workflow:
     needs: test


### PR DESCRIPTION
Gomega no longer supports go1.19 so we cannot run tests without pinning to an older release.

Go1.19 is EoL so stop testing with this version.

Updated test matrix to only test supported Go versions "stable" (currently 1.21) and "oldstable" (1.20).