### PR TITLE
ci: update ci image reference

### DIFF
--- a/ci/unit-tests.yml
+++ b/ci/unit-tests.yml
@@ -17,8 +17,8 @@
 platform: linux
 
 image_resource:
-  type: docker-image
-  source: {repository: cflondonservices/services-enablement-ci}
+  type: registry-image
+  source: {repository: dedicatedmysql/odb-ci}
 
 inputs:
   - name: on-demand-services-sdk


### PR DESCRIPTION
The current unit-tests Concourse image reference is an old image with an unsupported Go version.