### PR TITLE
Support stemcell name property

### DIFF
--- a/bosh/bosh_manifest.go
+++ b/bosh/bosh_manifest.go
@@ -102,6 +102,7 @@ type Stemcell struct {
 	Alias   string `yaml:"alias"`
 	OS      string `yaml:"os"`
 	Version string `yaml:"version"`
+	Name    string `yaml:"name,omitempty"`
 }
 
 type InstanceGroup struct {

--- a/bosh/bosh_manifest_test.go
+++ b/bosh/bosh_manifest_test.go
@@ -17,7 +17,7 @@ package bosh_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -245,7 +245,7 @@ var _ = Describe("(de)serialising BOSH manifests", func() {
 	It("serialises bosh manifests", func() {
 		cwd, err := os.Getwd()
 		Expect(err).NotTo(HaveOccurred())
-		manifestBytes, err := ioutil.ReadFile(filepath.Join(cwd, "fixtures", "manifest.yml"))
+		manifestBytes, err := os.ReadFile(filepath.Join(cwd, "fixtures", "manifest.yml"))
 		Expect(err).NotTo(HaveOccurred())
 
 		serialisedManifest, err := yaml.Marshal(sampleManifest)
@@ -256,7 +256,7 @@ var _ = Describe("(de)serialising BOSH manifests", func() {
 	It("deserialises bosh manifest features into struct", func() {
 		cwd, err := os.Getwd()
 		Expect(err).NotTo(HaveOccurred())
-		manifestBytes, err := ioutil.ReadFile(filepath.Join(cwd, "fixtures", "manifest.yml"))
+		manifestBytes, err := os.ReadFile(filepath.Join(cwd, "fixtures", "manifest.yml"))
 		Expect(err).NotTo(HaveOccurred())
 
 		manifest := bosh.BoshManifest{}

--- a/bosh/bosh_suite_test.go
+++ b/bosh/bosh_suite_test.go
@@ -16,10 +16,10 @@
 package bosh_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestBosh(t *testing.T) {

--- a/bosh/fixtures/manifest_template.yml
+++ b/bosh/fixtures/manifest_template.yml
@@ -9,6 +9,9 @@ stemcells:
   - alias: greatest
     os: Windows
     version: "3.1"
+    {{ if  ne (index . "StemcellName") "" -}}
+    name: {{.StemcellName}}
+    {{- end }}
 
 instance_groups:
   - name: jerb

--- a/bosh/job.go
+++ b/bosh/job.go
@@ -72,7 +72,7 @@ func (j Job) AddConsumesLink(name, fromJob string) Job {
 	return j.addConsumesLink(name, ConsumesLink{From: fromJob})
 }
 
-func (j Job) AddCrossDeploymentConsumesLink(name, fromJob string, deployment string) Job {
+func (j Job) AddCrossDeploymentConsumesLink(name, fromJob, deployment string) Job {
 	return j.addConsumesLink(name, ConsumesLink{From: fromJob, Deployment: deployment})
 }
 

--- a/integration_tests/command_line_handler_test.go
+++ b/integration_tests/command_line_handler_test.go
@@ -71,7 +71,8 @@ var (
 
 	expectedRequestParams = map[string]interface{}{"key": "foo", "bar": "baz"}
 
-	expectedResultantBoshManifest = bosh.BoshManifest{Name: "deployment-name",
+	expectedResultantBoshManifest = bosh.BoshManifest{
+		Name: "deployment-name",
 		Releases: []bosh.Release{
 			{
 				Name:    "a-release",
@@ -110,7 +111,8 @@ var (
 
 	expectedPlan = expectedPreviousPlan
 
-	expectedPreviousManifest = bosh.BoshManifest{Name: "another-deployment-name",
+	expectedPreviousManifest = bosh.BoshManifest{
+		Name: "another-deployment-name",
 		Releases: []bosh.Release{
 			{
 				Name:    "a-release",
@@ -124,7 +126,8 @@ var (
 				OS:      "Windows",
 				Version: "3.1",
 			},
-		}}
+		},
+	}
 
 	expectedBindingID = "bindingId"
 
@@ -138,7 +141,6 @@ var (
 )
 
 var _ = Describe("Command line handler", func() {
-
 	BeforeEach(func() {
 		doNotImplementInterfaces = false
 		stdout = new(bytes.Buffer)
@@ -163,7 +165,8 @@ var _ = Describe("Command line handler", func() {
 	Describe("generate-manifest subcommand", func() {
 		Describe("with positional arguments", func() {
 			It("succeeds without optional parameters", func() {
-				exitCode = startPassingCommandAndGetExitCode([]string{"generate-manifest",
+				exitCode = startPassingCommandAndGetExitCode([]string{
+					"generate-manifest",
 					toJson(expectedServiceDeployment),
 					toJson(expectedCurrentPlan),
 					toJson(expectedRequestParams),
@@ -201,7 +204,8 @@ var _ = Describe("Command line handler", func() {
 			})
 
 			It("exits 1 and logs when a generic error occurs", func() {
-				exitCode = startFailingCommandAndGetExitCode([]string{"generate-manifest",
+				exitCode = startFailingCommandAndGetExitCode([]string{
+					"generate-manifest",
 					toJson(expectedServiceDeployment),
 					toJson(expectedCurrentPlan),
 					toJson(expectedRequestParams),
@@ -763,6 +767,7 @@ func toYaml(obj interface{}) string {
 	Expect(err).NotTo(HaveOccurred())
 	return string(str)
 }
+
 func toJson(obj interface{}) string {
 	str, err := json.Marshal(obj)
 	Expect(err).NotTo(HaveOccurred())

--- a/integration_tests/testharness/main.go
+++ b/integration_tests/testharness/main.go
@@ -46,13 +46,13 @@ func main() {
 type manifestGenerator struct{}
 
 func (m *manifestGenerator) GenerateManifest(params serviceadapter.GenerateManifestParams) (serviceadapter.GenerateManifestOutput, error) {
-
 	if os.Getenv(testvariables.OperationFailsKey) == OperationShouldFail {
 		fmt.Fprintf(os.Stderr, "not valid")
 		return serviceadapter.GenerateManifestOutput{}, errors.New("some message to the user")
 	}
 
-	manifest := bosh.BoshManifest{Name: "deployment-name",
+	manifest := bosh.BoshManifest{
+		Name: "deployment-name",
 		Releases: []bosh.Release{
 			{
 				Name:    "a-release",

--- a/serviceadapter/command_line_handler.go
+++ b/serviceadapter/command_line_handler.go
@@ -19,11 +19,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
-
-	"strings"
-
 	"path/filepath"
+	"sort"
+	"strings"
 )
 
 // CommandLineHandler contains all of the implementers required for the service adapter interface

--- a/serviceadapter/command_line_handler_test.go
+++ b/serviceadapter/command_line_handler_test.go
@@ -16,15 +16,13 @@
 package serviceadapter_test
 
 import (
+	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-
-	"bytes"
 
 	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
 	"github.com/pivotal-cf/on-demand-services-sdk/serviceadapter"
@@ -188,7 +186,6 @@ var _ = Describe("CommandLineHandler", func() {
 			err := handler.Handle([]string{commandName, "generate-manifest"}, outputBuffer, errorBuffer, bytes.NewBufferString(""))
 
 			Expect(err).To(BeACLIError(serviceadapter.NotImplementedExitCode, "generate-manifest not implemented"))
-
 		})
 
 		It("returns a missing args error when arguments are missing", func() {
@@ -427,7 +424,8 @@ var _ = Describe("CommandLineHandler", func() {
 
 		It("returns a missing args error when request JSON is missing", func() {
 			err := handler.Handle([]string{
-				commandName, "delete-binding", previousManifestYAML}, outputBuffer, errorBuffer, bytes.NewBufferString(""))
+				commandName, "delete-binding", previousManifestYAML,
+			}, outputBuffer, errorBuffer, bytes.NewBufferString(""))
 
 			Expect(err).To(BeACLIError(1, "Missing arguments for delete-binding. Usage:"))
 		})
@@ -486,7 +484,7 @@ var _ = Describe("CommandLineHandler", func() {
 
 			Expect(fakeSchemaGenerator.GeneratePlanSchemaArgsForCall(0).Plan).To(Equal(plan))
 
-			contents, err := ioutil.ReadAll(outputBuffer)
+			contents, err := io.ReadAll(outputBuffer)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(contents).To(MatchJSON(toJson(expectedPlanSchema)))
 		})
@@ -528,7 +526,7 @@ var _ = Describe("CommandLineHandler", func() {
 
 			Expect(fakeSchemaGenerator.GeneratePlanSchemaArgsForCall(0).Plan).To(Equal(plan))
 
-			contents, err := ioutil.ReadAll(outputBuffer)
+			contents, err := io.ReadAll(outputBuffer)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(contents).To(MatchJSON(toJson(expectedPlanSchema)))
 		})

--- a/serviceadapter/create_binding.go
+++ b/serviceadapter/create_binding.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 type CreateBindingAction struct {
@@ -45,7 +45,7 @@ func (a *CreateBindingAction) ParseArgs(reader io.Reader, args []string) (InputP
 		return inputParams, nil
 	}
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return inputParams, CLIHandlerError{ErrorExitCode, fmt.Sprintf("error reading input params JSON, error: %s", err)}
 	}

--- a/serviceadapter/dashboard_url.go
+++ b/serviceadapter/dashboard_url.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 type DashboardUrlAction struct {
@@ -43,7 +43,7 @@ func (d *DashboardUrlAction) ParseArgs(reader io.Reader, args []string) (InputPa
 		return inputParams, nil
 	}
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return inputParams, CLIHandlerError{ErrorExitCode, fmt.Sprintf("error reading input params JSON, error: %s", err)}
 	}

--- a/serviceadapter/delete_binding.go
+++ b/serviceadapter/delete_binding.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 type DeleteBindingAction struct {
@@ -44,7 +44,7 @@ func (d *DeleteBindingAction) ParseArgs(reader io.Reader, args []string) (InputP
 		return inputParams, nil
 	}
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return inputParams, CLIHandlerError{ErrorExitCode, fmt.Sprintf("error reading input params JSON, error: %s", err)}
 	}

--- a/serviceadapter/domain.go
+++ b/serviceadapter/domain.go
@@ -110,8 +110,10 @@ type PlanSchema struct {
 	ServiceBinding  ServiceBindingSchema  `json:"service_binding"`
 }
 
-type ManifestSecrets map[string]string
-type DNSAddresses map[string]string
+type (
+	ManifestSecrets map[string]string
+	DNSAddresses    map[string]string
+)
 
 type DashboardUrl struct {
 	DashboardUrl string `json:"dashboard_url"`
@@ -165,8 +167,10 @@ type InputParams struct {
 	TextOutput          bool                          `json:"-"`
 }
 
-type ODBManagedSecrets map[string]interface{}
-type BOSHConfigs map[string]string
+type (
+	ODBManagedSecrets map[string]interface{}
+	BOSHConfigs       map[string]string
+)
 
 type GenerateManifestOutput struct {
 	Manifest          bosh.BoshManifest `json:"manifest"`

--- a/serviceadapter/domain.go
+++ b/serviceadapter/domain.go
@@ -289,6 +289,7 @@ func (r ServiceReleases) Validate() error {
 }
 
 type Stemcell struct {
+	Name    string `json:"stemcell_name,omitempty"`
 	OS      string `json:"stemcell_os" validate:"required"`
 	Version string `json:"stemcell_version" validate:"required"`
 }

--- a/serviceadapter/generate_manifest.go
+++ b/serviceadapter/generate_manifest.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 
 	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 type GenerateManifestAction struct {
@@ -46,7 +46,7 @@ func (g *GenerateManifestAction) ParseArgs(reader io.Reader, args []string) (Inp
 		return inputParams, nil
 	}
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return inputParams, CLIHandlerError{ErrorExitCode, fmt.Sprintf("error reading input params JSON, error: %s", err)}
 	}

--- a/serviceadapter/generate_plan_schemas.go
+++ b/serviceadapter/generate_plan_schemas.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/pkg/errors"
 )
@@ -53,7 +52,7 @@ func (g *GeneratePlanSchemasAction) ParseArgs(reader io.Reader, args []string) (
 		return inputParams, nil
 	}
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return inputParams, CLIHandlerError{ErrorExitCode, fmt.Sprintf("error reading input params JSON, error: %s", err)}
 	}

--- a/serviceadapter/generate_plan_schemas_test.go
+++ b/serviceadapter/generate_plan_schemas_test.go
@@ -157,7 +157,6 @@ var _ = Describe("GeneratePlanSchemas", func() {
 				err := action.Execute(expectedInputParams, fakeWriter)
 				Expect(err).To(MatchError(ContainSubstring("marshalling plan schema")))
 			})
-
 		})
 	})
 })

--- a/serviceadapter/instance_group_mapping.go
+++ b/serviceadapter/instance_group_mapping.go
@@ -28,7 +28,6 @@ func GenerateInstanceGroupsWithNoProperties(
 	stemcell string,
 	deploymentInstanceGroupsToJobs map[string][]string,
 ) ([]bosh.InstanceGroup, error) {
-
 	if len(instanceGroups) == 0 {
 		return nil, fmt.Errorf("no instance groups provided")
 	}

--- a/serviceadapter/service_deployment_test.go
+++ b/serviceadapter/service_deployment_test.go
@@ -24,9 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var (
-	validDeployment serviceadapter.ServiceDeployment
-)
+var validDeployment serviceadapter.ServiceDeployment
 
 var _ = Describe("ServiceDeployment", func() {
 	BeforeEach(func() {
@@ -47,7 +45,6 @@ var _ = Describe("ServiceDeployment", func() {
 	})
 
 	Describe("(De)serialising JSON", func() {
-
 		var expectedServiceDeployment serviceadapter.ServiceDeployment
 
 		serviceDeploymentJSON := []byte(`{

--- a/serviceadapter/service_deployment_test.go
+++ b/serviceadapter/service_deployment_test.go
@@ -38,6 +38,7 @@ var _ = Describe("ServiceDeployment", func() {
 				},
 			},
 			Stemcells: []serviceadapter.Stemcell{{
+				Name:    "beos-fips-stemcell",
 				OS:      "BeOS",
 				Version: "2",
 			}},
@@ -58,6 +59,7 @@ var _ = Describe("ServiceDeployment", func() {
         ]
       }],
       "stemcells": [{
+		"stemcell_name": "beos-fips-stemcell",
         "stemcell_os": "BeOS",
         "stemcell_version": "2"
       }]

--- a/serviceadapter/serviceadapter_suite_test.go
+++ b/serviceadapter/serviceadapter_suite_test.go
@@ -16,19 +16,18 @@
 package serviceadapter_test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
 	"github.com/pivotal-cf/on-demand-services-sdk/serviceadapter"
-
-	"encoding/json"
-	"testing"
 
 	"gopkg.in/yaml.v2"
 )
@@ -110,7 +109,8 @@ func defaultPreviousPlan() serviceadapter.Plan {
 }
 
 func defaultManifest() bosh.BoshManifest {
-	return bosh.BoshManifest{Name: "another-deployment-name",
+	return bosh.BoshManifest{
+		Name: "another-deployment-name",
 		Releases: []bosh.Release{
 			{
 				Name:    "a-release",
@@ -129,7 +129,8 @@ func defaultManifest() bosh.BoshManifest {
 }
 
 func defaultPreviousManifest() bosh.BoshManifest {
-	return bosh.BoshManifest{Name: "another-deployment-name",
+	return bosh.BoshManifest{
+		Name: "another-deployment-name",
 		Releases: []bosh.Release{
 			{
 				Name:    "a-release",
@@ -212,8 +213,7 @@ func NewFakeReader() io.Reader {
 	return &FakeReader{}
 }
 
-type FakeReader struct {
-}
+type FakeReader struct{}
 
 func (f *FakeReader) Read(b []byte) (int, error) {
 	return 1, fmt.Errorf("fool!")


### PR DESCRIPTION
Broadcom has started supporting FIPS enabled stemcells whose version
matches the non-FIPS stemcells and without a name specified the FIPS may
unintentionally be used when a deployment might not support FIPS.

To avoid this allow consumers to set a stemcell name property to point
to the expected stemcell name. This allows BOSH to ensure the desired
stemcell is always used and not unintentionally deploying with the wrong
variant.