### PR TITLE
Remove xenial references

### DIFF
--- a/bosh/bosh_manifest_test.go
+++ b/bosh/bosh_manifest_test.go
@@ -82,7 +82,7 @@ var _ = Describe("(de)serialising BOSH manifests", func() {
 				Exclude: bosh.PlacementRule{
 					Stemcell: []bosh.PlacementRuleStemcell{
 						{
-							OS: "ubuntu-xenial",
+							OS: "ubuntu-jammy",
 						},
 					},
 					Deployments: []string{

--- a/bosh/fixtures/manifest.yml
+++ b/bosh/fixtures/manifest.yml
@@ -23,7 +23,7 @@ addons:
         - a-team
     exclude:
       stemcell:
-        - os: ubuntu-xenial
+        - os: ubuntu-jammy
       deployments:
         - dep3
       jobs:


### PR DESCRIPTION
This is purely a cosmetic change in a unit test to reference "ubuntu-jammy" rather than "ubuntu-xenial".